### PR TITLE
HashTableWithProbing Class Implementation

### DIFF
--- a/DataStructures-Algorithms-CSharp/DataStructures/HashTable/CustomHashTable.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/HashTable/CustomHashTable.cs
@@ -87,7 +87,7 @@ public class CustomHashTable
 
     #region Methods
 
-    private int GetTableHashCode(int key) => key.GetHashCode() % _table.Length;
+    private int GetTableHashCode(int key) => Math.Abs(key.GetHashCode()) % _table.Length;
 
     #endregion
 

--- a/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
@@ -49,11 +49,46 @@ public class HashTableWithProbing
         }
 
         _table[tableHashCode] = tableKeyValuePair;
+        count++;
+    }
+
+    public string? Get(int key)
+    {
+        if (IsEmpty())
+        {
+            throw new InvalidOperationException("The table is empty.");
+        }
+
+        var tableHashKey = GetTableHashCode(key);
+
+        if (_table[tableHashKey].Key == key)
+        {
+            return _table[tableHashKey].Value;
+        }
+
+        var nextItem = tableHashKey + 1;
+
+        while (nextItem != tableHashKey)
+        {
+            if (_table[nextItem].Key == key)
+            {
+                return _table[nextItem].Value;
+            }
+
+            nextItem++;
+            if (nextItem == _table.Length)
+            {
+                nextItem = nextItem % _table.Length;
+            }
+        }
+
+        throw new InvalidOperationException($"There is no data for the provided key: {key}");
     }
 
     #region Methods
 
     private bool IsFull() => count == _table.Length;
+    private bool IsEmpty() => count == 0;
 
     private int GetTableHashCode(int key) => Math.Abs(key.GetHashCode()) % _table.Length;
 

--- a/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
@@ -14,6 +14,7 @@ public class HashTableWithProbing
     }
 
     private TableKeyValuePair[] _table;
+    private int count;
 
     public HashTableWithProbing(int size)
     {
@@ -22,7 +23,40 @@ public class HashTableWithProbing
 
     public void Add(int key, string value)
     {
+        if (IsFull())
+        {
+            throw new InvalidOperationException("The table is full.");
+        }
 
+        var tableHashCode = GetTableHashCode(key);
+
+        var tableKeyValuePair = new TableKeyValuePair(key, value);
+
+        if (_table[tableHashCode] is null)
+        {
+            _table[tableHashCode] = tableKeyValuePair;
+            return;
+        }
+
+        while (_table[tableHashCode] != null)
+        {
+            tableHashCode++;
+
+            if (tableHashCode == _table.Length)
+            {
+                tableHashCode = tableHashCode % _table.Length;
+            }
+        }
+
+        _table[tableHashCode] = tableKeyValuePair;
     }
+
+    #region Methods
+
+    private bool IsFull() => count == _table.Length;
+
+    private int GetTableHashCode(int key) => Math.Abs(key.GetHashCode()) % _table.Length;
+
+    #endregion
 
 }

--- a/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
@@ -1,0 +1,28 @@
+namespace DataStructures_Algorithms_CSharp.DataStructures.HashTable;
+
+public class HashTableWithProbing
+{
+    class TableKeyValuePair
+    {
+        public TableKeyValuePair(int key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
+        public int Key { get; set; }
+        public string Value { get; set; } = null!;
+    }
+
+    private TableKeyValuePair[] _table;
+
+    public HashTableWithProbing(int size)
+    {
+        _table = new TableKeyValuePair[size];
+    }
+
+    public void Add(int key, string value)
+    {
+
+    }
+
+}

--- a/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/HashTable/HashTableWithProbing.cs
@@ -13,7 +13,7 @@ public class HashTableWithProbing
         public string Value { get; set; } = null!;
     }
 
-    private TableKeyValuePair[] _table;
+    private TableKeyValuePair?[] _table;
     private int count;
 
     public HashTableWithProbing(int size)
@@ -61,18 +61,18 @@ public class HashTableWithProbing
 
         var tableHashKey = GetTableHashCode(key);
 
-        if (_table[tableHashKey].Key == key)
+        if (_table[tableHashKey]?.Key == key)
         {
-            return _table[tableHashKey].Value;
+            return _table[tableHashKey]!.Value;
         }
 
-        var nextItem = tableHashKey + 1;
+        var nextItem = (tableHashKey + 1) % _table.Length;
 
         while (nextItem != tableHashKey)
         {
-            if (_table[nextItem].Key == key)
+            if (_table[nextItem]?.Key == key)
             {
-                return _table[nextItem].Value;
+                return _table[nextItem]!.Value;
             }
 
             nextItem++;
@@ -83,6 +83,40 @@ public class HashTableWithProbing
         }
 
         throw new InvalidOperationException($"There is no data for the provided key: {key}");
+    }
+
+    public void Remove(int key)
+    {
+        if (IsEmpty())
+        {
+            throw new InvalidOperationException("The table is empty.");
+        }
+
+        var tableHashKey = GetTableHashCode(key);
+
+        if (_table[tableHashKey]!.Key == key)
+        {
+            _table[tableHashKey] = null;
+            return;
+        }
+
+        var nextItem = (tableHashKey + 1) % _table.Length;
+
+        while (nextItem != tableHashKey)
+        {
+            if (_table[nextItem]?.Key == key)
+            {
+                _table[nextItem] = null;
+            }
+            nextItem++;
+
+            if (nextItem == _table.Length)
+            {
+                nextItem = nextItem % _table.Length;
+            }
+        }
+
+        throw new InvalidOperationException($"There is no data found for the provided key: {key}.");
     }
 
     #region Methods


### PR DESCRIPTION
This PR introduces the HashTableWithProbing class, which provides hash table operations with linear probing for collision resolution.

Features:

- Add(key, value): Adds a key-value pair to the hash table.
- Get(key): Retrieves the value associated with the specified key from the hash table.
- Remove(key): Removes the key-value pair associated with the specified key from the hash table.