### PR TITLE
TreeSize method implementation

### DIFF
--- a/DataStructures-Algorithms-CSharp/DataStructures/Trees/CustomBinaryTree.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/Trees/CustomBinaryTree.cs
@@ -274,6 +274,15 @@ public class CustomBinaryTree
         }
     }
 
+    public int Size() => Size(_root);
+
+    private int Size(Node? root)
+    {
+        if (root is null) return 0;
+
+        return Size(root.Left) + 1 + Size(root.Right);
+    }
+
     #region Methods
 
     private bool IsEmpty() => _root is null;


### PR DESCRIPTION
This PR introduces a new method in CustomBinaryTree class, Size, which can be used to get the size of the tree.

Features:

- Size(root): returns the total nodes of the tree. 