### PR TITLE
Fixes in Remove Method in Heap

### DIFF
--- a/DataStructures-Algorithms-CSharp/DataStructures/Heap/CustomHeap.cs
+++ b/DataStructures-Algorithms-CSharp/DataStructures/Heap/CustomHeap.cs
@@ -46,7 +46,16 @@ public class CustomHeap
 
         while (index <= count && !IsValidParent(index))
         {
-            var largestChild = _heap[LeftIndex(index)] > _heap[RightIndex(index)] ? LeftIndex(index) : RightIndex(index);
+            int largestChild = 0;
+
+            if (!HasRightChild(index))
+            {
+                largestChild = LeftIndex(index);
+            }
+            else
+            {
+                largestChild = _heap[LeftIndex(index)] > _heap[RightIndex(index)] ? LeftIndex(index) : RightIndex(index);
+            }
 
             Swap(index, largestChild);
             index = largestChild;
@@ -90,6 +99,11 @@ public class CustomHeap
 
         return isValid;
     }
+
+    private bool HasLeftChild(int index) => LeftIndex(index) <= count;
+
+    private bool HasRightChild(int index) => RightIndex(index) <= count;
+
     #endregion
 
 }


### PR DESCRIPTION
This PR introduces some fixes in remove method in heap class.

Features:

It will now first check if the root element has only one child, in that case, it will use do bubble down operation with left child, otherwise it will pick up the largest child and will do the bubble down operation. 